### PR TITLE
[민지수] TodoList CRUD

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 - [x] todo list에 todoItem을 키보드로 입력하여 추가하기
 - [x] todo list의 체크박스를 클릭하여 complete 상태로 변경 (li tag 에 completed class 추가)
+- [x] todo list의 x버튼을 이용해서 해당 엘리먼트를 삭제
 
 ## 📝 License
 

--- a/README.md
+++ b/README.md
@@ -11,41 +11,11 @@
 
 <br>
 
-## ⚙️ Before Started
+## 첫번째 미션 - Todo List!
 
-#### <img alt="Tip" src="https://img.shields.io/static/v1.svg?label=&message=Tip&style=flat-square&color=673ab8"> 로컬에서 서버 띄워서 손쉽게 static resources 변경 및 확인하는 방법
+### 요구사항
 
-로컬에서 웹서버를 띄워 html, css, js 등을 실시간으로 손쉽게 테스트해 볼 수 있습니다. 이를 위해서는 우선 npm이 설치되어 있어야 합니다. 구글에 `npm install` 이란 키워드로 각자의 운영체제에 맞게끔 npm을 설치해주세요. 이후 아래의 명령어를 통해 실시간으로 웹페이지를 테스트해볼 수 있습니다.
-
-```
-npm install -g live-server
-```
-
-실행은 아래의 커맨드로 할 수 있습니다.
-
-```
-live-server 폴더명
-```
-
-<br>
-
-## 👨‍💻 Code Review 👩‍💻
-아래 링크들에 있는 리뷰 가이드를 보고, 좋은 코드 리뷰 문화를 만들어 나가려고 합니다.  
-- [코드리뷰 가이드1](https://edykim.com/ko/post/code-review-guide/)
-- [코드리뷰 가이드2](https://wiki.lucashan.space/code-review/01.intro.html#_1-code%EB%A5%BC-%EB%A6%AC%EB%B7%B0%ED%95%98%EB%8A%94-%EC%82%AC%EB%9E%8C%EB%93%A4%EC%9D%80-%EC%96%B4%EB%96%A4%EA%B2%83%EC%9D%84-%EC%A4%91%EC%A0%90%EC%A0%81%EC%9C%BC%EB%A1%9C-%EC%82%B4%ED%8E%B4%EC%95%BC%ED%95%98%EB%8A%94%EA%B0%80)
-
-<br>
-
-## 👏 Contributing
-만약 미션 수행 중에 개선사항이 보인다면, 언제든 자유롭게 PR을 보내주세요. 
-
-<br>
-
-## 🐞 Bug Report
-
-버그를 발견한다면, [Issues](https://github.com/EastjunDev/frontend/issues) 에 등록 후 @eastjun에게 dm을 보내주세요.
-
-<br>
+- [x] todo list에 todoItem을 키보드로 입력하여 추가하기
 
 ## 📝 License
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@
 - [x] todo list의 체크박스를 클릭하여 complete 상태로 변경 (li tag 에 completed class 추가)
 - [x] todo list의 x버튼을 이용해서 해당 엘리먼트를 삭제
 - [x] todo list를 더블클릭했을 때 input 모드로 변경. (li tag 에 editing class 추가) 단 이때 수정을 완료하지 않은 상태에서 esc키를 누르면 수정되지 않은 채로 다시 view 모드로 복귀
+- [x] todo list의 item갯수를 count한 갯수를 리스트의 하단에 보여주기
+- [x] todo list의 상태값을 확인하여, 해야할 일과, 완료한 일을 클릭하면 해당 상태의 아이템만 보여주기
+
+### 심화 요구사항
+
+- [x] localStorage에 데이터를 저장하여, TodoItem의 CRUD를 반영하기. 따라서 새로고침하여도 저장된 데이터를 확인할 수 있어야 함
+
+
 
 ## 📝 License
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ### 요구사항
 
 - [x] todo list에 todoItem을 키보드로 입력하여 추가하기
+- [x] todo list의 체크박스를 클릭하여 complete 상태로 변경 (li tag 에 completed class 추가)
 
 ## 📝 License
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [x] todo list에 todoItem을 키보드로 입력하여 추가하기
 - [x] todo list의 체크박스를 클릭하여 complete 상태로 변경 (li tag 에 completed class 추가)
 - [x] todo list의 x버튼을 이용해서 해당 엘리먼트를 삭제
+- [x] todo list를 더블클릭했을 때 input 모드로 변경. (li tag 에 editing class 추가) 단 이때 수정을 완료하지 않은 상태에서 esc키를 누르면 수정되지 않은 채로 다시 view 모드로 복귀
 
 ## 📝 License
 

--- a/index.html
+++ b/index.html
@@ -10,12 +10,7 @@
     <section class="todoapp">
       <div>
         <h1>TODOS</h1>
-        <input
-          id="new-todo-title"
-          class="new-todo"
-          placeholder="할일을 추가해주세요"
-          autofocus
-        />
+        <input id="new-todo-title" class="new-todo" placeholder="할일을 추가해주세요" autofocus />
       </div>
       <div class="main">
         <input class="toggle-all" type="checkbox" />
@@ -36,6 +31,6 @@
         </ul>
       </div>
     </section>
-    <script src="js/app.js"></script>
+    <script type="module" src="js/app.js"></script>
   </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -3,22 +3,52 @@ import TodoInput from './components/TodoInput.js';
 
 class App {
   constructor() {
-    this.todoItems = [];
+    this.todoItems = [
+      {
+        content: 'ABCD',
+        isCompleted: false,
+        editing: false
+      },
+      {
+        content: 'EFGH',
+        isCompleted: true,
+        editing: false
+      },
+      {
+        content: 'qwerqwer',
+        isCompleted: false,
+        editing: false
+      }
+    ];
+
+    const getNewItem = (content, isCompleted = false, editing = false) => {
+      return {
+        content: content,
+        isCompleted: isCompleted,
+        editing: editing
+      };
+    };
 
     this.todoList = new TodoList({
       $element: document.getElementById('todo-list'),
       items: this.todoItems,
       onClickToggle: id => {
         const newTodoItems = [...this.todoItems];
-        newTodoItems[id] = {
-          content: this.todoItems[id].content,
-          isCompleted: !this.todoItems[id].isCompleted
-        };
+        newTodoItems[id] = getNewItem(this.todoItems[id].content, !this.todoItems[id].isCompleted);
         this.setState(newTodoItems);
       },
       onClickDestroy: id => {
         const newTodoItems = [...this.todoItems];
         newTodoItems.splice(id, 1);
+        this.setState(newTodoItems);
+      },
+      onToggleEdit: (id, newContent, editing) => {
+        const newTodoItems = [...this.todoItems];
+        newTodoItems[id] = getNewItem(
+          newContent ? newContent.trim() : this.todoItems[id].content,
+          this.todoItems[id].isCompleted,
+          editing
+        );
         this.setState(newTodoItems);
       }
     });
@@ -26,7 +56,7 @@ class App {
     this.todoInput = new TodoInput({
       $element: document.getElementById('new-todo-title'),
       onEnter: newContent => {
-        this.setState([...this.todoItems, { content: newContent, isCompleted: false }]);
+        this.setState([...this.todoItems, getNewItem(newContent)]);
       }
     });
   }

--- a/js/app.js
+++ b/js/app.js
@@ -8,9 +8,17 @@ class App {
     this.todoList = new TodoList({
       $element: document.getElementById('todo-list'),
       items: this.todoItems,
-      onClickCheck: id => {
+      onClickToggle: id => {
         const newTodoItems = [...this.todoItems];
-        newTodoItems[id].isCompleted = !newTodoItems[id].isCompleted;
+        newTodoItems[id] = {
+          content: this.todoItems[id].content,
+          isCompleted: !this.todoItems[id].isCompleted
+        };
+        this.setState(newTodoItems);
+      },
+      onClickDestroy: id => {
+        const newTodoItems = [...this.todoItems];
+        newTodoItems.splice(id, 1);
         this.setState(newTodoItems);
       }
     });

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,27 @@
+import TodoList from './components/TodoList.js';
+import TodoInput from './components/TodoInput.js';
+
+class App {
+  constructor() {
+    this.todoItems = [];
+
+    this.todoList = new TodoList({
+      $element: document.getElementById('todo-list'),
+      items: this.todoItems
+    });
+
+    this.todoInput = new TodoInput({
+      $element: document.getElementById('new-todo-title'),
+      onEnter: newContent => {
+        this.setState([...this.todoItems, { content: newContent, isCompleted: false }]);
+      }
+    });
+  }
+
+  setState(newItems) {
+    this.todoList.setState(newItems);
+    this.todoItems = newItems;
+  }
+}
+
+new App();

--- a/js/app.js
+++ b/js/app.js
@@ -5,7 +5,7 @@ import { FILTER } from './constants.js';
 import { STORAGE_KEY, $TODO_INPUT, $TODO_LIST } from './config.js';
 
 const getWindowLocation = () => {
-  return window.location.hash.substr(2);
+  return window.location.hash.substring(2);
 };
 
 const getNewItem = (id, content, isCompleted = false, editing = false) => {
@@ -127,9 +127,10 @@ class App {
   }
 
   filterTodoItems(filter, todoItems) {
-    return filter === ''
-      ? todoItems
-      : todoItems.filter(item => (filter === FILTER.COMPLETED) === item.isCompleted);
+    const isCompletedFilter = filter === FILTER.COMPLETED;
+    return filter !== ''
+      ? todoItems.filter(item => isCompletedFilter === item.isCompleted)
+      : todoItems;
   }
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,25 +1,23 @@
 import TodoList from './components/TodoList.js';
 import TodoInput from './components/TodoInput.js';
+import CounterContainer from './components/CounterContainer.js';
+import { FILTER } from './constants.js';
+
+const STORAGE_KEY = 'js-todo-list';
 
 class App {
+  appFilter = window.location.hash.substr(2);
+
   constructor() {
-    this.todoItems = [
-      {
-        content: 'ABCD',
-        isCompleted: false,
-        editing: false
-      },
-      {
-        content: 'EFGH',
-        isCompleted: true,
-        editing: false
-      },
-      {
-        content: 'qwerqwer',
-        isCompleted: false,
-        editing: false
+    const storageData = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    this.todoItems = storageData || [];
+
+    new TodoInput({
+      $element: document.getElementById('new-todo-title'),
+      onEnter: newContent => {
+        this.setState([...this.todoItems, getNewItem(newContent)], this.appFilter);
       }
-    ];
+    });
 
     const getNewItem = (content, isCompleted = false, editing = false) => {
       return {
@@ -31,16 +29,21 @@ class App {
 
     this.todoList = new TodoList({
       $element: document.getElementById('todo-list'),
-      items: this.todoItems,
+      items:
+        this.appFilter === ''
+          ? this.todoItems
+          : this.todoItems.filter(
+              item => (this.appFilter === FILTER.COMPLETED) === item.isCompleted
+            ),
       onClickToggle: id => {
         const newTodoItems = [...this.todoItems];
         newTodoItems[id] = getNewItem(this.todoItems[id].content, !this.todoItems[id].isCompleted);
-        this.setState(newTodoItems);
+        this.setState(newTodoItems, this.appFilter);
       },
       onClickDestroy: id => {
         const newTodoItems = [...this.todoItems];
         newTodoItems.splice(id, 1);
-        this.setState(newTodoItems);
+        this.setState(newTodoItems, this.appFilter);
       },
       onToggleEdit: (id, newContent, editing) => {
         const newTodoItems = [...this.todoItems];
@@ -49,21 +52,38 @@ class App {
           this.todoItems[id].isCompleted,
           editing
         );
-        this.setState(newTodoItems);
+        this.setState(newTodoItems, this.appFilter);
       }
     });
 
-    this.todoInput = new TodoInput({
-      $element: document.getElementById('new-todo-title'),
-      onEnter: newContent => {
-        this.setState([...this.todoItems, getNewItem(newContent)]);
-      }
+    this.countContainer = new CounterContainer({
+      totalCount: this.todoItems.length,
+      selectedFilter: this.appFilter
+    });
+
+    // 필터 변경 되었을 때
+    window.addEventListener('hashchange', () => {
+      const newFilter = window.location.hash.substr(2);
+      this.setState(this.todoItems, newFilter);
     });
   }
 
-  setState(newItems) {
-    this.todoList.setState(newItems);
+  setState(newItems, newFilter) {
     this.todoItems = newItems;
+    this.appFilter = newFilter;
+
+    const filteredItems =
+      this.appFilter === ''
+        ? this.todoItems
+        : this.todoItems.filter(item => (this.appFilter === FILTER.COMPLETED) === item.isCompleted);
+
+    this.todoList.setState(filteredItems);
+    this.countContainer.setState({
+      newCount: filteredItems.length,
+      newFilter: this.appFilter
+    });
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newItems));
   }
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -7,7 +7,12 @@ class App {
 
     this.todoList = new TodoList({
       $element: document.getElementById('todo-list'),
-      items: this.todoItems
+      items: this.todoItems,
+      onClickCheck: id => {
+        const newTodoItems = [...this.todoItems];
+        newTodoItems[id].isCompleted = !newTodoItems[id].isCompleted;
+        this.setState(newTodoItems);
+      }
     });
 
     this.todoInput = new TodoInput({

--- a/js/components/CounterContainer.js
+++ b/js/components/CounterContainer.js
@@ -1,0 +1,21 @@
+import TodoCount from './TodoCount.js';
+import TodoFilter from './TodoFilter.js';
+
+export default class CounterContainer {
+  constructor({ totalCount, selectedFilter }) {
+    this.todoCount = new TodoCount({
+      $element: document.getElementsByClassName('todo-count')[0],
+      count: totalCount
+    });
+
+    this.todoFilter = new TodoFilter({
+      $element: document.querySelector('ul.filters'),
+      selectedFilter
+    });
+  }
+
+  setState({ newCount, newFilter }) {
+    this.todoCount.setState(newCount);
+    this.todoFilter.setState(newFilter);
+  }
+}

--- a/js/components/FilterContainer.js
+++ b/js/components/FilterContainer.js
@@ -1,7 +1,7 @@
 import TodoCount from './TodoCount.js';
 import TodoFilter from './TodoFilter.js';
 
-export default class CounterContainer {
+export default class FilterContainer {
   constructor({ totalCount, selectedFilter }) {
     this.todoCount = new TodoCount({
       $element: document.getElementsByClassName('todo-count')[0],

--- a/js/components/FilterContainer.js
+++ b/js/components/FilterContainer.js
@@ -1,15 +1,16 @@
 import TodoCount from './TodoCount.js';
 import TodoFilter from './TodoFilter.js';
+import { $TODO_COUNT, $TODO_FILTER } from '../config.js';
 
 export default class FilterContainer {
   constructor({ totalCount, selectedFilter }) {
     this.todoCount = new TodoCount({
-      $element: document.getElementsByClassName('todo-count')[0],
+      $element: $TODO_COUNT,
       count: totalCount
     });
 
     this.todoFilter = new TodoFilter({
-      $element: document.querySelector('ul.filters'),
+      $element: $TODO_FILTER,
       selectedFilter
     });
   }

--- a/js/components/TodoCount.js
+++ b/js/components/TodoCount.js
@@ -1,0 +1,17 @@
+export default class TodoCount {
+  constructor({ $element, count }) {
+    this.$element = $element;
+    this.count = count;
+
+    this.render();
+  }
+
+  render() {
+    this.$element.innerHTML = `총 <strong>${this.count}</strong> 개`;
+  }
+
+  setState(newCount) {
+    this.count = newCount;
+    this.render();
+  }
+}

--- a/js/components/TodoCount.js
+++ b/js/components/TodoCount.js
@@ -1,5 +1,14 @@
+const isCountInteger = data => {
+  return data && Number.isInteger(data) && data >= 0;
+};
+
 export default class TodoCount {
   constructor({ $element, count }) {
+    if (!isCountInteger(count)) {
+      console.log('[TodoCount] 데이터가 올바르지 않습니다.');
+      return;
+    }
+
     this.$element = $element;
     this.count = count;
 

--- a/js/components/TodoFilter.js
+++ b/js/components/TodoFilter.js
@@ -1,0 +1,27 @@
+import { FILTER } from '../constants.js';
+
+export default class TodoFilter {
+  constructor(props) {
+    const { $element, selectedFilter } = props;
+    this.$element = $element;
+    this.selectedFilter = selectedFilter;
+    this.render();
+  }
+
+  getSelected(filter) {
+    return this.selectedFilter === filter ? 'selected' : '';
+  }
+
+  render() {
+    const $filterElements = this.$element.getElementsByTagName('a');
+
+    $filterElements[0].className = `${FILTER.ALL} ${this.getSelected('')}`;
+    $filterElements[1].className = `${FILTER.ACTIVE} ${this.getSelected(FILTER.ACTIVE)}`;
+    $filterElements[2].className = `${FILTER.COMPLETED} ${this.getSelected(FILTER.COMPLETED)}`;
+  }
+
+  setState(newFilter) {
+    this.selectedFilter = newFilter;
+    this.render();
+  }
+}

--- a/js/components/TodoFilter.js
+++ b/js/components/TodoFilter.js
@@ -1,10 +1,22 @@
 import { FILTER } from '../constants.js';
 
+const isFilterValid = filter => {
+  const filterValue = filter || FILTER.ALL;
+  return Object.keys(FILTER).some(key => FILTER[key] === filterValue);
+};
+
 export default class TodoFilter {
   constructor(props) {
     const { $element, selectedFilter } = props;
+
+    if (!isFilterValid(selectedFilter)) {
+      console.log('[TodoFilter] 데이터가 올바르지 않습니다.');
+      return;
+    }
+
     this.$element = $element;
     this.selectedFilter = selectedFilter;
+
     this.render();
   }
 

--- a/js/components/TodoInput.js
+++ b/js/components/TodoInput.js
@@ -1,0 +1,14 @@
+export default class TodoInput {
+  constructor({ $element, onEnter }) {
+    this.$element = $element;
+    this.handleEnter = onEnter;
+
+    this.$element.addEventListener('keypress', e => {
+      const value = e.target.value.trim();
+      if (e.key === 'Enter' && value) {
+        this.handleEnter(value);
+        this.$element.value = '';
+      }
+    });
+  }
+}

--- a/js/components/TodoList.js
+++ b/js/components/TodoList.js
@@ -23,12 +23,31 @@ export const Item = props => {
   };
 };
 
+const isNil = data => {
+  return data === null || data === undefined;
+};
+
+const isTodoItemValid = param => {
+  // 데이터가 null / undefined 또는 array가 아닐 경우 판별
+  if (isNil(param) || !Array.isArray(param)) {
+    return false;
+  }
+
+  // 데이터 내용이 이상할 때 판별
+  return param.every(item => toString.call(item) === '[object Object]');
+};
+
 export class TodoList {
   constructor(props) {
     const { $element, items, onClickToggle, onClickDestroy, onToggleEdit } = props;
     this.$element = $element;
     this.todoItems = items;
     this.isEditing = -1; // 현재 편집 중인 아이템의 id 저장
+
+    if (!isTodoItemValid(items)) {
+      console.log('[TodoList] 데이터가 올바르지 않습니다.');
+      return;
+    }
 
     this.render();
 

--- a/js/components/TodoList.js
+++ b/js/components/TodoList.js
@@ -1,0 +1,23 @@
+const itemLabel = ({ content, isCompleted }) => {
+  return `<li ${isCompleted ? 'class=completed' : ''}><label>${content}</label></li>`;
+};
+
+export default class TodoList {
+  constructor({ $element, items }) {
+    this.$element = $element;
+    this.items = items;
+
+    this.render();
+  }
+
+  render() {
+    this.$element.innerHTML = `${this.items
+      .map(item => itemLabel({ content: item.content, isCompleted: item.isCompleted }))
+      .join('')}`;
+  }
+
+  setState(newItems) {
+    this.items = newItems;
+    this.render();
+  }
+}

--- a/js/components/TodoList.js
+++ b/js/components/TodoList.js
@@ -2,19 +2,25 @@ const Item = ({ id, content, isCompleted }) => {
   return `<li ${isCompleted ? 'class=completed' : ''}>
   <input class="toggle" type="checkbox" value="${id}" ${isCompleted ? 'checked' : ''}>
   <label>${content}</label>
+  <button class="destroy" name="${id}"></button>
   </li>`;
 };
 
 export default class TodoList {
   constructor(props) {
-    const { $element, items, onClickCheck } = props;
+    const { $element, items, onClickToggle, onClickDestroy } = props;
     this.$element = $element;
     this.items = items;
 
     this.render();
     this.$element.addEventListener('click', e => {
       if (e.target.nodeName == 'INPUT') {
-        onClickCheck(e.target.value);
+        onClickToggle(e.target.value);
+      }
+
+      if (e.target.nodeName == 'BUTTON') {
+        console.log(e.target.name);
+        onClickDestroy(e.target.name);
       }
     });
   }

--- a/js/components/TodoList.js
+++ b/js/components/TodoList.js
@@ -1,18 +1,27 @@
-const itemLabel = ({ content, isCompleted }) => {
-  return `<li ${isCompleted ? 'class=completed' : ''}><label>${content}</label></li>`;
+const Item = ({ id, content, isCompleted }) => {
+  return `<li ${isCompleted ? 'class=completed' : ''}>
+  <input class="toggle" type="checkbox" value="${id}" ${isCompleted ? 'checked' : ''}>
+  <label>${content}</label>
+  </li>`;
 };
 
 export default class TodoList {
-  constructor({ $element, items }) {
+  constructor(props) {
+    const { $element, items, onClickCheck } = props;
     this.$element = $element;
     this.items = items;
 
     this.render();
+    this.$element.addEventListener('click', e => {
+      if (e.target.nodeName == 'INPUT') {
+        onClickCheck(e.target.value);
+      }
+    });
   }
 
   render() {
     this.$element.innerHTML = `${this.items
-      .map(item => itemLabel({ content: item.content, isCompleted: item.isCompleted }))
+      .map((item, id) => Item({ id: id, content: item.content, isCompleted: item.isCompleted }))
       .join('')}`;
   }
 

--- a/js/components/TodoList.js
+++ b/js/components/TodoList.js
@@ -41,18 +41,9 @@ export class TodoList {
       this.isEditing = -1;
     };
 
-    // 편집 중인 아이템 외의 기능 선택 시 편집 완료
-    window.addEventListener(
-      'click', // autofocus가 실행되지 않아 blur 이벤트 대신 사용 중
-      e => {
-        if (this.isEditing !== -1 && e.target.className !== 'edit') {
-          e.stopPropagation();
-          handleFinishEdit(true);
-          return;
-        }
-      },
-      true
-    );
+    this.$element.addEventListener('focusout', e => {
+      handleFinishEdit(true);
+    });
 
     // 마우스 클릭 이벤트
     this.$element.addEventListener('click', e => {
@@ -76,12 +67,15 @@ export class TodoList {
         const editId = e.target.htmlFor;
         this.isEditing = editId;
         onToggleEdit(editId, '', true);
+
+        // 편집 아이템으로 포커스
+        const editInputElement = document.querySelector(`input.edit[name="${editId}"]`);
+        editInputElement.focus();
       }
     });
 
     // 키보드 입력 이벤트
-    // autofocus가 실행되지 않아 input에 focus 안 되어 window 이벤트로 등록
-    window.addEventListener('keydown', e => {
+    this.$element.addEventListener('keydown', e => {
       if (this.isEditing !== -1) {
         if (e.key === 'Escape') {
           handleFinishEdit(false);

--- a/js/components/TodoList.js
+++ b/js/components/TodoList.js
@@ -42,7 +42,9 @@ export class TodoList {
     };
 
     this.$element.addEventListener('focusout', e => {
-      handleFinishEdit(true);
+      if (e.target.className === 'edit') {
+        handleFinishEdit(true);
+      }
     });
 
     // 마우스 클릭 이벤트

--- a/js/components/TodoList.js
+++ b/js/components/TodoList.js
@@ -1,38 +1,104 @@
-const Item = ({ id, content, isCompleted }) => {
-  return `<li ${isCompleted ? 'class=completed' : ''}>
-  <input class="toggle" type="checkbox" value="${id}" ${isCompleted ? 'checked' : ''}>
-  <label>${content}</label>
-  <button class="destroy" name="${id}"></button>
-  </li>`;
+const ContentWrapper = ({ id, content, isCompleted }) => {
+  const checked = isCompleted ? 'checked' : '';
+  return `<div class="view">
+    <input class="toggle" type="checkbox" name="${id}" ${checked}/>
+    <label for="${id}">${content}</label>
+    <button class="destroy" name="${id}"></button>
+  </div>`;
+};
+
+const EditInput = ({ id, content }) => {
+  return `<input class="edit" name="${id}" value="${content}" autofocus/>`;
+};
+
+const Item = props => {
+  const { isCompleted, editing } = props;
+  const completed = isCompleted ? 'completed' : '';
+  const edit = editing ? 'editing' : '';
+  return `<li class="${completed} ${edit}">${ContentWrapper(props)}${EditInput(props)}</li>`;
 };
 
 export default class TodoList {
   constructor(props) {
-    const { $element, items, onClickToggle, onClickDestroy } = props;
+    const { $element, items, onClickToggle, onClickDestroy, onToggleEdit } = props;
+
     this.$element = $element;
-    this.items = items;
+    this.todoItems = items;
+    this.isEditing = -1; // 현재 편집 중인 아이템의 id 저장
 
     this.render();
+
+    const handleFinishEdit = save => {
+      onToggleEdit(
+        this.isEditing,
+        save ? document.getElementsByClassName('edit')[this.isEditing].value : '',
+        false
+      );
+      this.isEditing = -1;
+    };
+
+    // 마우스 클릭 이벤트
     this.$element.addEventListener('click', e => {
-      if (e.target.nodeName == 'INPUT') {
-        onClickToggle(e.target.value);
+      // 편집 중인 아이템 외의 기능 선택 시 편집 완료
+      if (this.isEditing !== -1 && e.target.className !== 'edit') {
+        handleFinishEdit(true);
+        return;
       }
 
-      if (e.target.nodeName == 'BUTTON') {
-        console.log(e.target.name);
+      // 아이템 완료/미완료 선택
+      if (e.target.nodeName === 'INPUT' && e.target.className === 'toggle') {
+        onClickToggle(e.target.name);
+        return;
+      }
+
+      // 아이템 삭제
+      if (e.target.nodeName === 'BUTTON' && e.target.className === 'destroy') {
         onClickDestroy(e.target.name);
+        return;
+      }
+    });
+
+    // 마우스 더블 클릭 이벤트
+    this.$element.addEventListener('dblclick', e => {
+      // 아이템 편집
+      if (e.target.nodeName === 'LABEL') {
+        const editId = e.target.htmlFor;
+        this.isEditing = editId;
+        onToggleEdit(editId, '', true);
+      }
+    });
+
+    // 키보드 입력 이벤트
+    this.$element.addEventListener('keydown', e => {
+      if (this.isEditing !== -1) {
+        if (e.key === 'Escape') {
+          handleFinishEdit(false);
+          return;
+        }
+
+        if (e.key === 'Enter') {
+          handleFinishEdit(true);
+          return;
+        }
       }
     });
   }
 
   render() {
-    this.$element.innerHTML = `${this.items
-      .map((item, id) => Item({ id: id, content: item.content, isCompleted: item.isCompleted }))
+    this.$element.innerHTML = `${this.todoItems
+      .map((item, id) =>
+        Item({
+          id: id,
+          content: item.content,
+          isCompleted: item.isCompleted,
+          editing: item.editing
+        })
+      )
       .join('')}`;
   }
 
   setState(newItems) {
-    this.items = newItems;
+    this.todoItems = newItems;
     this.render();
   }
 }

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,8 @@
+const STORAGE_KEY = 'js-todo-list';
+
+const $TODO_INPUT = document.getElementById('new-todo-title');
+const $TODO_LIST = document.getElementById('todo-list');
+const $TODO_COUNT = document.getElementsByClassName('todo-count')[0];
+const $TODO_FILTER = document.querySelector('ul.filters');
+
+export { STORAGE_KEY, $TODO_INPUT, $TODO_LIST, $TODO_COUNT, $TODO_FILTER };

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,0 +1,5 @@
+export const FILTER = {
+  ALL: 'all',
+  ACTIVE: 'active',
+  COMPLETED: 'completed'
+};


### PR DESCRIPTION
## 첫번째 미션 - Todo List!

### 요구사항

- [x] todo list에 todoItem을 키보드로 입력하여 추가하기
- [x] todo list의 체크박스를 클릭하여 complete 상태로 변경 (li tag 에 completed class 추가)
- [x] todo list의 x버튼을 이용해서 해당 엘리먼트를 삭제
- [x] todo list를 더블클릭했을 때 input 모드로 변경. (li tag 에 editing class 추가) 단 이때 수정을 완료하지 않은 상태에서 esc키를 누르면 수정되지 않은 채로 다시 view 모드로 복귀
- [x] todo list의 item갯수를 count한 갯수를 리스트의 하단에 보여주기
- [x] todo list의 상태값을 확인하여, 해야할 일과, 완료한 일을 클릭하면 해당 상태의 아이템만 보여주기

### 심화 요구사항

- [x] localStorage에 데이터를 저장하여, TodoItem의 CRUD를 반영하기. 따라서 새로고침하여도 저장된 데이터를 확인할 수 있어야 함


### 어려웠던 부분

- Chrome에서 테스트하고 있는데 "Autofocus processing was blocked because a document's URL has a fragment '#/'." 이런 에러가 뜨면서 모든 input element의 autofocus 속성이 적용되지 않는 문제가 있습니다. 아직 해결하지 못한 상태이고 원래 의도했던대로 구현하지 못한 부분이 있습니다.

- 필터 처리 적용 하는 부분과 편집 기능을 추가할 때 어려웠습니다.

- 편집 상태에서 다른 동작이 들어올 경우에 대한 처리가 까다로웠습니다.